### PR TITLE
Refactor Commands to use Deferred command builders rather than manual schedulers

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,7 +68,7 @@ public class RobotContainer {
     public final Wrist wristSub;
     public final Climb climbSub;
     public final Underglow underglowSub;
-    public final Chute chuteSub ;
+    public final Chute chuteSub;
     public final AlgaeIntake algaeIntakeSub = new AlgaeIntake();
     public final ArmStateManager armState = new ArmStateManager();
     public final DynamicAutoBuilder dynAutoBuilder;
@@ -174,9 +174,9 @@ public class RobotContainer {
 
     private final SwerveRequest.FieldCentric drive = new SwerveRequest.FieldCentric()
             .withDeadband(0.1)
-            .withRotationalDeadband( 0.1) // Add a
-                                                                                                               // 10%
-                                                                                                               // deadband
+            .withRotationalDeadband(0.1) // Add a
+                                         // 10%
+                                         // deadband
             .withDriveRequestType(DriveRequestType.OpenLoopVoltage); // Use open-loop control for drive motors
     private final SwerveRequest.ApplyRobotSpeeds nudge = new SwerveRequest.ApplyRobotSpeeds();
     private final SwerveRequest.SwerveDriveBrake brake = new SwerveRequest.SwerveDriveBrake();
@@ -187,7 +187,7 @@ public class RobotContainer {
         elevatorSub = new Elevator(robot);
         armSub = new Arm(robot);
         wristSub = new Wrist(robot);
-        chuteSub = new Chute() ;
+        chuteSub = new Chute();
         underglowSub = new Underglow(chuteSub);
 
         climbSub = new Climb(
@@ -380,35 +380,35 @@ public class RobotContainer {
         /***************** ARM POSITION *****************/
 
         moveToTravellingButton = new JoystickButton(operatorController, XboxControllerConstants.RightStick);
-        moveToTravellingButton.onTrue(setArmPosTravellingCmd);
+        moveToTravellingButton.onTrue(setArmPosTravellingCmd.command());
 
         moveToLoadCoralButton = new JoystickButton(operatorController, XboxControllerConstants.RightBumper);
-        moveToLoadCoralButton.onTrue(setArmPosLoadCoralCmd);
+        moveToLoadCoralButton.onTrue(setArmPosLoadCoralCmd.command());
 
         // moveToAlgaeButton = new JoystickButton(operatorController,
         // XboxControllerConstants.LeftTrigger);
         // moveToAlgaeButton.onTrue(setArmPosAlgaeCmd);
 
         removeAlgaeButton = new JoystickButton(operatorController, XboxControllerConstants.LeftBumper);
-        removeAlgaeButton.onTrue(removeAlgaeCmd);
+        removeAlgaeButton.onTrue(removeAlgaeCmd.command());
 
         moveToLevel1Button = new JoystickButton(operatorController, XboxControllerConstants.ButtonY);
-        moveToLevel1Button.onTrue(setArmPosLevel1Cmd);
+        moveToLevel1Button.onTrue(setArmPosLevel1Cmd.command());
 
         moveToLevel2Button = new JoystickButton(operatorController, XboxControllerConstants.ButtonX);
-        moveToLevel2Button.onTrue(setArmPosLevel2Cmd);
+        moveToLevel2Button.onTrue(setArmPosLevel2Cmd.command());
 
         moveToLevel3Button = new JoystickButton(operatorController, XboxControllerConstants.ButtonB);
-        moveToLevel3Button.onTrue(setArmPosLevel3Cmd);
+        moveToLevel3Button.onTrue(setArmPosLevel3Cmd.command());
 
         moveToLevel4Button = new JoystickButton(operatorController, XboxControllerConstants.ButtonA);
-        moveToLevel4Button.onTrue(setArmPosLevel4Cmd);
+        moveToLevel4Button.onTrue(setArmPosLevel4Cmd.command());
 
         // Joystick testingController = new Joystick(0) ;
         startClimbButton = new JoystickButton(operatorController, XboxControllerConstants.HamburgerButton);
         // startClimbButton = new JoystickButton(testingController,
         // LogitechDAConstants.ButtonY); // just for testing
-        startClimbButton.onTrue(startClimbingCmd);
+        startClimbButton.onTrue(startClimbingCmd.command());
 
         /***************** ALGAE INTAKE *****************/
 
@@ -441,7 +441,7 @@ public class RobotContainer {
 
         scoreCoralButton = new JoystickButton(operatorController, XboxControllerConstants.WindowButton);
         // scoreCoralButton.onTrue(scoreCoralCmd);
-        scoreCoralButton.onTrue(scoreCoralCmd);
+        scoreCoralButton.onTrue(scoreCoralCmd.command());
 
         autoAlignAlgaeButton = new JoystickButton(driverController, LogitechExtreme3DConstants.Button5);
         autoAlignAlgaeButton.whileTrue(
@@ -560,6 +560,15 @@ public class RobotContainer {
         }));
     }
 
+    public enum Group1State {
+        Scoring,
+        Removing,
+        MovingElevator,
+        Stopping,
+        Running,
+        Done,
+    }
+
     public void configurePathPlanner() {
 
         RobotConfig config;
@@ -573,17 +582,17 @@ public class RobotContainer {
         }
 
         /* PATHPLANNER INIT */
-        NamedCommands.registerCommand("setPositionCoralL1", setArmPosLevel1Cmd);
-        NamedCommands.registerCommand("setPositionCoralL2", setArmPosLevel2Cmd);
-        NamedCommands.registerCommand("setPositionCoralL3", setArmPosLevel3Cmd);
-        NamedCommands.registerCommand("setPositionCoralL4", setArmPosLevel4Cmd);
+        NamedCommands.registerCommand("setPositionCoralL1", setArmPosLevel1Cmd.command());
+        NamedCommands.registerCommand("setPositionCoralL2", setArmPosLevel2Cmd.command());
+        NamedCommands.registerCommand("setPositionCoralL3", setArmPosLevel3Cmd.command());
+        NamedCommands.registerCommand("setPositionCoralL4", setArmPosLevel4Cmd.command());
         // NamedCommands.registerCommand("", setArmPosLevel4Cmd);
 
-        NamedCommands.registerCommand("setPositionTraveling", setArmPosTravellingCmd);
+        NamedCommands.registerCommand("setPositionTraveling", setArmPosTravellingCmd.command());
 
-        NamedCommands.registerCommand("setPositionLoadCoral", setArmPosLoadCoralCmd);
-        NamedCommands.registerCommand("startOuttake", scoreCoralCmd);
-        NamedCommands.registerCommand("startOuttakeWithoutTravelling", scoreCoralCmdWithoutTravelling);
+        NamedCommands.registerCommand("setPositionLoadCoral", setArmPosLoadCoralCmd.command());
+        NamedCommands.registerCommand("startOuttake", scoreCoralCmd.command());
+        NamedCommands.registerCommand("startOuttakeWithoutTravelling", scoreCoralCmdWithoutTravelling.command());
 
         // NamedCommands.registerCommand("StartAlgaeOuttake", setArmPosAlgaeCmd);
 
@@ -616,20 +625,25 @@ public class RobotContainer {
         // autoChooser.addOption("[TEST] Box Auto", new DeferredCommand(() ->
         // driveSub.ChoreoAuto("Box Auto"), Set.of(driveSub)));
 
-
         Command commandGroup1 = Commands.sequence(
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.Scoring)),
                 // wpk need to fix magic numbers
                 new ScoreCoralWithoutTravel(armState, elevatorSub, armSub, wristSub,
-                gripperSub),
+                        gripperSub).command(),
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.Removing)),
                 new InstantCommand(() -> gripperSub.startAlgaeRemoval()),
                 // move the elevator up to strip the algae
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.MovingElevator)),
                 new MoveElevator(elevatorSub,
                         elevatorSub.getDesiredElevatorHeightInches(),
                         Constants.ArmConstants.ElevatorAlgaeRemovalVelocity,
                         16,
                         12),
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.Stopping)),
                 new InstantCommand(() -> gripperSub.stop()),
-                new PositionGripper(armState, ArmState.Running, elevatorSub, armSub, wristSub));
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.Running)),
+                new PositionGripper(armState, ArmState.Running, elevatorSub, armSub, wristSub).command(),
+                new InstantCommand(() -> Logger.recordOutput("Auto/Group1", Group1State.Done)));
 
         autoChooser.addOption("Leave Zone",
                 new DeferredCommand(() -> driveSub.ChoreoAuto("[USED] Leave Zone"), Set.of(driveSub)));
@@ -637,11 +651,14 @@ public class RobotContainer {
                 new DeferredCommand(() -> driveSub.ChoreoAuto("[USED] Score L1 Path"), Set.of(driveSub)));
         autoChooser.addOption("Score L3 Path",
                 new DeferredCommand(() -> driveSub.ChoreoAuto("[USED] Score L3 Path"), Set.of(driveSub)));
-        autoChooser.addOption("2-Coral_OtherBarge", new DeferredCommand(() ->
-            driveSub.CustomChoreoAuto("[USED] 2CoralP", true, setArmPosLevel1Cmd, commandGroup1), Set.of(driveSub)));
+        autoChooser.addOption("2-Coral_OtherBarge",
+                new DeferredCommand(
+                        () -> driveSub.CustomChoreoAuto("[USED] 2CoralP", true, setArmPosLevel1Cmd, commandGroup1),
+                        Set.of(driveSub)));
         autoChooser.addOption("2-Coral-OppositeAllianceBarge", new DeferredCommand(
-                () -> driveSub.CustomChoreoAuto("[USED] 2CoralP", false, setArmPosLevel1Cmd, commandGroup1), Set.of(driveSub)));
-    
+                () -> driveSub.CustomChoreoAuto("[USED] 2CoralP", false, setArmPosLevel1Cmd, commandGroup1),
+                Set.of(driveSub)));
+
         // autoChooser.addOption("VisionTest", new PathPlannerAuto("TestVision"));
 
         Shuffleboard.getTab("Match").add("Path Name", autoChooser);

--- a/src/main/java/frc/robot/commands/DoClimb.java
+++ b/src/main/java/frc/robot/commands/DoClimb.java
@@ -19,8 +19,6 @@ import frc.robot.subsystems.Climb.ClimbState;
 public class DoClimb {
     /** Creates a new StartClimbing. */
 
-    private Command comm;
-
     private final Climb climbSub;
     private final Arm armSub;
     private final ArmStateManager armStateManager;
@@ -33,14 +31,9 @@ public class DoClimb {
         this.armStateManager = armStateManager;
         this.elevatorSub = elevatorSub;
         this.wristSub = wristSub;
-
-        // comm = new SequentialCommandGroup();
-
-        // Use addRequirements() here to declare subsystem dependencies.
     }
 
     public Command command() {
-        // comm = new SequentialCommandGroup();
         return Commands.defer(
                 () -> {
                     if (climbSub.getCurrentState() == ClimbState.Idle) {
@@ -59,7 +52,7 @@ public class DoClimb {
                         return Commands.none();
                     }
                 },
-                Set.of(climbSub, armSub));
+                Set.of(climbSub, armSub, elevatorSub, wristSub));
     }
 
 }

--- a/src/main/java/frc/robot/commands/DoClimb.java
+++ b/src/main/java/frc/robot/commands/DoClimb.java
@@ -4,8 +4,10 @@
 
 package frc.robot.commands;
 
+import java.util.Set;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Climb;
@@ -14,7 +16,7 @@ import frc.robot.subsystems.Wrist;
 import frc.robot.subsystems.ArmState;
 import frc.robot.subsystems.Climb.ClimbState;
 
-public class DoClimb extends Command {
+public class DoClimb {
     /** Creates a new StartClimbing. */
 
     private Command comm;
@@ -34,52 +36,30 @@ public class DoClimb extends Command {
 
         // comm = new SequentialCommandGroup();
 
-        addRequirements(climbSub, armSub);
         // Use addRequirements() here to declare subsystem dependencies.
     }
 
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-        //comm = new SequentialCommandGroup();
-        if (climbSub.getCurrentState() == ClimbState.Idle) {
-            // comm = new InstantCommand(() -> climbSub.goToUnwind()) ;
-            comm =         new PositionGripper(armStateManager, ArmState.Climb, elevatorSub, armSub, wristSub);
-            // comm = Commands.sequence(
-            //         new PositionGripper(armStateManager, ArmState.Climb, elevatorSub, armSub, wristSub),
-            //         new InstantCommand(() -> climbSub.goToUnwind())
-            //         );
+    public Command command() {
+        // comm = new SequentialCommandGroup();
+        return Commands.defer(
+                () -> {
+                    if (climbSub.getCurrentState() == ClimbState.Idle) {
+                        // comm = new InstantCommand(() -> climbSub.goToUnwind()) ;
+                        return new PositionGripper(armStateManager, ArmState.Climb, elevatorSub, armSub, wristSub)
+                                .command();
+                        // comm = Commands.sequence(
+                        // new PositionGripper(armStateManager, ArmState.Climb, elevatorSub, armSub,
+                        // wristSub),
+                        // new InstantCommand(() -> climbSub.goToUnwind())
+                        // );
 
-        } else if (climbSub.getCurrentState() == ClimbState.ReadyToLatch) {
-            comm =  new InstantCommand(() -> climbSub.goToWind());
-        } else {
-            comm = null ;
-        }
-        if ( comm != null) {
-            comm.schedule();
-        }
-    }
-    public void execute() {
-        
-        // if (climbSub.getCurrentState() == ClimbState.Idle) {
-        //     comm = Commands.sequence(new InstantCommand(() -> climbSub.goToUnwind()));
-        // } else if (climbSub.getCurrentState() == ClimbState.ReadyToLatch) {
-        //     comm = Commands.sequence(new InstantCommand(() -> climbSub.goToWind()));
-        // }
-
-        // comm.schedule();
+                    } else if (climbSub.getCurrentState() == ClimbState.ReadyToLatch) {
+                        return new InstantCommand(() -> climbSub.goToWind());
+                    } else {
+                        return Commands.none();
+                    }
+                },
+                Set.of(climbSub, armSub));
     }
 
-    @Override
-    public boolean isFinished() {
-        if ( comm != null) {
-            return (comm.isFinished());
-        }
-        return true ;
-    }
-
-    @Override
-    public void end(boolean interrupted) {
-
-    }
 }

--- a/src/main/java/frc/robot/commands/LoadCoralFromChute.java
+++ b/src/main/java/frc/robot/commands/LoadCoralFromChute.java
@@ -4,6 +4,8 @@
 
 package frc.robot.commands;
 
+import java.util.Set;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -16,73 +18,48 @@ import frc.robot.subsystems.Gripper;
 import frc.robot.subsystems.Wrist;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class LoadCoralFromChute extends Command {
+public class LoadCoralFromChute {
 
-    Elevator theElevator ;
+    Elevator theElevator;
     Arm theArm;
-    Wrist theWrist ;
+    Wrist theWrist;
     Gripper theGripper;
-    ArmStateManager armState ;
-
-    private Command currentCommand;
+    ArmStateManager armState;
 
     /** Creates a new LoadCoralFromChute. */
-    public LoadCoralFromChute(Elevator e, Arm a, Wrist w, Gripper g, ArmStateManager asm ) {
-        theElevator = e ;
+    public LoadCoralFromChute(Elevator e, Arm a, Wrist w, Gripper g, ArmStateManager asm) {
+        theElevator = e;
         theArm = a;
-        theWrist = w ;
+        theWrist = w;
         theGripper = g;
-        armState = asm ;
+        armState = asm;
 
         // Use addRequirements() here to declare subsystem dependencies.
-        addRequirements(theElevator, theArm, theWrist, theGripper);
     }
 
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
+    public Command command() {
+        return Commands.defer(() -> {
+            if (armState.getCurrentState() != ArmState.WaitingForCoral) {
+                return new PositionGripper(armState, ArmState.WaitingForCoral, theElevator, theArm, theWrist).command();
+            } else {
+                double startingCarriageHeight = theElevator.getCarriageHeightInches();
+                return Commands.sequence(
+                        // move arm to load position
+                        // start gripper spinng to intake
+                        // wait for gripper to have coral or a timeoout
+                        // return gripper to load position
 
-        if ( armState.getCurrentState() != ArmState.WaitingForCoral ) {
-            // what should we do? Ignore it?
-            currentCommand = Commands.sequence(
-                new PositionGripper(armState, ArmState.WaitingForCoral, theElevator, theArm, theWrist)
-            ) ;
+                        // wpk need to fix magic numbers
+                        new MoveElevator(theElevator, 0.0, startingCarriageHeight - 3.0),
+                        new InstantCommand(() -> theGripper.startIntaking()),
+                        new MoveElevator(theElevator, 0.0, startingCarriageHeight),
+                        new WaitCommand(0.25),
+                        new StopGripper(theGripper),
+                        new PositionGripper(armState, ArmState.Running, theElevator, theArm, theWrist).command());
 
-        } else {
-            double startingCarriageHeight = theElevator.getCarriageHeightInches() ;
-            currentCommand = Commands.sequence(
-                // move arm to load position
-                // start gripper spinng to intake
-                // wait for gripper to have coral or a timeoout
-                // return gripper to load position
+            }
+        },
+                Set.of(theElevator, theArm, theWrist, theGripper));
 
-                // wpk need to fix magic numbers
-                new MoveElevator(theElevator, 0.0, startingCarriageHeight - 3.0) ,
-                new InstantCommand( () -> theGripper.startIntaking() ),
-                new MoveElevator(theElevator, 0.0, startingCarriageHeight) ,
-                new WaitCommand(0.25) ,
-                new StopGripper(theGripper) ,
-                new PositionGripper(armState, ArmState.Running, theElevator, theArm, theWrist)
-            ) ;
-
-        }
-
-        currentCommand.schedule();
-    }
-
-    // Called every time the scheduler runs while the command is scheduled.
-    @Override
-    public void execute() {
-    }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-    }
-
-    // Returns true when the command should end.
-    @Override
-    public boolean isFinished() {
-        return currentCommand.isFinished();
     }
 }

--- a/src/main/java/frc/robot/commands/PositionGripper.java
+++ b/src/main/java/frc/robot/commands/PositionGripper.java
@@ -53,7 +53,7 @@ public class PositionGripper {
         return Commands.defer(() -> {
             return transitionCommands.get(armStateManager.getCurrentState()).get(targetState);
         },
-                Set.of(theElevator, theArm, theWrist));
+        Set.of(theElevator, theArm, theWrist));
     }
 
     /** CHANGE: this version is just for testing */

--- a/src/main/java/frc/robot/commands/PositionGripper.java
+++ b/src/main/java/frc/robot/commands/PositionGripper.java
@@ -5,6 +5,7 @@
 package frc.robot.commands;
 
 import java.util.HashMap;
+import java.util.Set;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -16,71 +17,50 @@ import frc.robot.subsystems.Elevator;
 import frc.robot.subsystems.Wrist;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class PositionGripper extends Command {
+public class PositionGripper {
 
     private static final HashMap<ArmState, ArmStateParameters> positionDictionary = new HashMap<ArmState, ArmStateParameters>();
     private static final HashMap<ArmState, HashMap<ArmState, Command>> transitionCommands = new HashMap<ArmState, HashMap<ArmState, Command>>();
 
+    ArmStateManager armStateManager;
+    ArmState targetState;
 
-    ArmStateManager armStateManager ;
-    ArmState targetState ;
+    Command commandToRun;
 
-    Command commandToRun ;
-
-    Elevator theElevator ;
-    Arm theArm ;
-    Wrist theWrist ;
+    Elevator theElevator;
+    Arm theArm;
+    Wrist theWrist;
 
     /** Creates a new MoveArm. */
-    public PositionGripper(ArmStateManager asm, ArmState s, Elevator e, Arm a, Wrist w ) { 
-        this.armStateManager = asm ;
-        this.targetState = s ;
-        theElevator = e ;
-        theArm = a ;
-        theWrist = w ;
+    public PositionGripper(ArmStateManager asm, ArmState s, Elevator e, Arm a, Wrist w) {
+        this.armStateManager = asm;
+        this.targetState = s;
+        theElevator = e;
+        theArm = a;
+        theWrist = w;
 
-        addRequirements(theElevator, theArm, theWrist);
+        if (positionDictionary.isEmpty()) {
+            initializePositionDictionary();
+        }
+        if (transitionCommands.isEmpty()) {
+            buildTransitionCommands();
+        }
 
-        if ( positionDictionary.isEmpty() ) {
-            initializePositionDictionary() ;
-        }
-        if ( transitionCommands.isEmpty()) {
-            buildTransitionCommands() ;
-        }
-    
         // Use addRequirements() here to declare subsystem dependencies.
     }
 
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-        commandToRun = transitionCommands.get(armStateManager.getCurrentState()).get(targetState) ;
-        commandToRun.schedule();
+    public Command command() {
+        return Commands.defer(() -> {
+            return transitionCommands.get(armStateManager.getCurrentState()).get(targetState);
+        },
+                Set.of(theElevator, theArm, theWrist));
     }
-
-    // Called every time the scheduler runs while the command is scheduled.
-    @Override
-    public void execute() {
-    }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-    }
-
-    // Returns true when the command should end.
-    @Override
-    public boolean isFinished() {
-        return commandToRun.isFinished();
-    }
-
-
 
     /** CHANGE: this version is just for testing */
     private void initializePositionDictionary() {
         positionDictionary.put(ArmState.Level1, new ArmStateParameters(0, 0, 45, 90, 0.0));
         positionDictionary.put(ArmState.Level2, new ArmStateParameters(0, 8.0, 55, 0, 0));
-        positionDictionary.put(ArmState.Level3, new ArmStateParameters(9.0, 15, 55, 0,0));
+        positionDictionary.put(ArmState.Level3, new ArmStateParameters(9.0, 15, 55, 0, 0));
         positionDictionary.put(ArmState.Level4, new ArmStateParameters(27.65, 21.137, 48.34, 0, 0));
         positionDictionary.put(ArmState.WaitingForCoral, new ArmStateParameters(0, 16, -75, 0, 0));
         positionDictionary.put(ArmState.Running, new ArmStateParameters(0, 0, 90, 0, 0));
@@ -213,52 +193,44 @@ public class PositionGripper extends Command {
 
     // }
 
-
-    private Command createElevatorFirstCommand( ArmState targetState) {
+    private Command createElevatorFirstCommand(ArmState targetState) {
         Command c = Commands.sequence(
-            new InstantCommand( () -> armStateManager.setTargetState(targetState)) ,
-            new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(), positionDictionary.get(targetState).getCarriageHeight()),
-            new ParallelCommandGroup(
-                new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()) ,
-                new RotateWrist( theWrist, positionDictionary.get(targetState).getWristAngle() )
-            ),
-            new InstantCommand( () -> armStateManager.setCurrentState(targetState))
-        ) ;
-        return c ;
+                new InstantCommand(() -> armStateManager.setTargetState(targetState)),
+                new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(),
+                        positionDictionary.get(targetState).getCarriageHeight()),
+                new ParallelCommandGroup(
+                        new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()),
+                        new RotateWrist(theWrist, positionDictionary.get(targetState).getWristAngle())),
+                new InstantCommand(() -> armStateManager.setCurrentState(targetState)));
+        return c;
     }
 
-    private Command createStraightenArmFirstCommand( ArmState targetState) {
+    private Command createStraightenArmFirstCommand(ArmState targetState) {
         Command c = Commands.sequence(
-            new InstantCommand( () -> armStateManager.setTargetState(targetState)) ,
-            new ParallelCommandGroup(
-                new MoveArm(theArm, positionDictionary.get(ArmState.Running).getArmAngle()) ,
-                new RotateWrist( theWrist, positionDictionary.get(ArmState.Running).getWristAngle() )
-            ),
-            new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(), positionDictionary.get(targetState).getCarriageHeight()),
-            new ParallelCommandGroup(
-                new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()) ,
-                new RotateWrist( theWrist, positionDictionary.get(targetState).getWristAngle() )
-            ),
-            new InstantCommand( () -> armStateManager.setCurrentState(targetState))
-        ) ;
-        return c ;
+                new InstantCommand(() -> armStateManager.setTargetState(targetState)),
+                new ParallelCommandGroup(
+                        new MoveArm(theArm, positionDictionary.get(ArmState.Running).getArmAngle()),
+                        new RotateWrist(theWrist, positionDictionary.get(ArmState.Running).getWristAngle())),
+                new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(),
+                        positionDictionary.get(targetState).getCarriageHeight()),
+                new ParallelCommandGroup(
+                        new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()),
+                        new RotateWrist(theWrist, positionDictionary.get(targetState).getWristAngle())),
+                new InstantCommand(() -> armStateManager.setCurrentState(targetState)));
+        return c;
     }
 
-
-    private Command createParallelMovementCommand( ArmState targetState) {
+    private Command createParallelMovementCommand(ArmState targetState) {
         Command c = Commands.sequence(
-            new InstantCommand( () -> armStateManager.setTargetState(targetState)) ,
-            new ParallelCommandGroup(
-                new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(), positionDictionary.get(targetState).getCarriageHeight()),
-                new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()) ,
-                new RotateWrist( theWrist, positionDictionary.get(targetState).getWristAngle() )
-            ),
-            new InstantCommand( () -> armStateManager.setCurrentState(targetState))
-        ) ;
-        return c ;
+                new InstantCommand(() -> armStateManager.setTargetState(targetState)),
+                new ParallelCommandGroup(
+                        new MoveElevator(theElevator, positionDictionary.get(targetState).getElevatorHeight(),
+                                positionDictionary.get(targetState).getCarriageHeight()),
+                        new MoveArm(theArm, positionDictionary.get(targetState).getArmAngle()),
+                        new RotateWrist(theWrist, positionDictionary.get(targetState).getWristAngle())),
+                new InstantCommand(() -> armStateManager.setCurrentState(targetState)));
+        return c;
     }
-
-
 
     private void buildTransitionCommands() {
 
@@ -352,6 +324,5 @@ public class PositionGripper extends Command {
 
 
     }
-
 
 }

--- a/src/main/java/frc/robot/commands/ScoreCoral.java
+++ b/src/main/java/frc/robot/commands/ScoreCoral.java
@@ -4,6 +4,8 @@
 
 package frc.robot.commands;
 
+import java.util.Set;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -16,89 +18,66 @@ import frc.robot.subsystems.Gripper;
 import frc.robot.subsystems.Wrist;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class ScoreCoral extends Command {
+public class ScoreCoral {
 
-    private ArmStateManager armStateManager ;
+    private ArmStateManager armStateManager;
     private ArmState currentState;
 
-    private final Elevator theElevator ;
+    private final Elevator theElevator;
     private final Arm theArm;
-    private final Wrist theWrist ;
-    private final Gripper theGripper ;
-
-    private Command currentCommand;
-
+    private final Wrist theWrist;
+    private final Gripper theGripper;
 
     // private final Gripper gripperSub;
 
-    public ScoreCoral(ArmStateManager asm, Elevator e, Arm a, Wrist w,  Gripper g) {
-        armStateManager = asm ;
-        theElevator = e ;
-        theArm = a ;
-        theWrist = w ;
-        theGripper = g ;
-
-        addRequirements(theElevator, theArm, theWrist, theGripper );
+    public ScoreCoral(ArmStateManager asm, Elevator e, Arm a, Wrist w, Gripper g) {
+        armStateManager = asm;
+        theElevator = e;
+        theArm = a;
+        theWrist = w;
+        theGripper = g;
     }
 
+    public Command command() {
+        return Commands.defer(() -> {
+            currentState = armStateManager.getCurrentState();
 
-    private Command createL234ScoreCommand( double deltaElevatorHeight, double deltaCarriageHeight, double deltaArmAngle) {
+            if (currentState == ArmState.Level1) {
+                return Commands.sequence(
+                        new EjectCoral(theGripper).withTimeout(1.0),
+                        new StopGripper(theGripper),
+                        new PositionGripper(armStateManager, ArmState.Running, theElevator, theArm, theWrist)
+                                .command());
+            } else if (currentState == ArmState.Level2) {
+                return createL234ScoreCommand(0, -7.0, -30);
+            } else if (currentState == ArmState.Level3) {
+                return createL234ScoreCommand(0, -7.0, -30);
+            } else if (currentState == ArmState.Level4) {
+                return createL234ScoreCommand(0, -4.0, -30);
+            } else {
+                // can't score coral if your not at one of the levels
+                return new NoOpCommand();
+            }
+        },
+                Set.of(theElevator, theArm, theWrist, theGripper));
+
+    }
+
+    private Command createL234ScoreCommand(double deltaElevatorHeight, double deltaCarriageHeight,
+            double deltaArmAngle) {
 
         return Commands.sequence(
-            // new InstantCommand(() -> theGripper.setReleaseMode() ),
-            new ParallelCommandGroup(
-                new InstantCommand( ()-> theGripper.releaseCoral()),
-                // new MoveArm( theArm, theArm.getArmEncoderDegrees()+deltaArmAngle) ,
-                new MoveElevator(theElevator, theElevator.getDesiredElevatorHeightInches()+deltaElevatorHeight, theElevator.getDesiredCarriageHeightInches()+deltaCarriageHeight) 
-            ) ,
-            // new MoveElevator(theElevator, theElevator.getDesiredElevatorHeightInches()+deltaArmAngle, theElevator.getDesiredCarriageHeightInches()+deltaArmAngle-1.0), 
-            new InstantCommand( ()-> theGripper.stop()),
-            new PositionGripper(armStateManager, ArmState.Running, theElevator, theArm, theWrist)
-            );            
-    }
-
-
-
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-
-        currentState = armStateManager.getCurrentState();
-
-        if (currentState == ArmState.Level1) {
-            currentCommand = Commands.sequence(
-                new EjectCoral( theGripper).withTimeout(1.0) ,
-                new StopGripper(theGripper),
-                new PositionGripper(armStateManager, ArmState.Running, theElevator, theArm, theWrist) 
-            ) ;
-        } else if (currentState == ArmState.Level2) {
-            currentCommand = createL234ScoreCommand(0, -7.0, -30) ;
-        } else if (currentState == ArmState.Level3) {
-            currentCommand = createL234ScoreCommand(0, -7.0, -30) ;
-        } else if (currentState == ArmState.Level4){
-            currentCommand = createL234ScoreCommand(0, -4.0, -30) ;
-        } else {
-            // can't score coral if your not at one of the levels
-            currentCommand = new NoOpCommand() ;
-        }
-        currentCommand.schedule();
-    }
-
-
-    // Called every time the scheduler runs while the command is scheduled.
-    @Override
-    public void execute() {
-    }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-    }
-
-    // Returns true when the command should end.
-    @Override
-    public boolean isFinished() {
-        return currentCommand.isFinished() ;
+                // new InstantCommand(() -> theGripper.setReleaseMode() ),
+                new ParallelCommandGroup(
+                        new InstantCommand(() -> theGripper.releaseCoral()),
+                        // new MoveArm( theArm, theArm.getArmEncoderDegrees()+deltaArmAngle) ,
+                        new MoveElevator(theElevator,
+                                theElevator.getDesiredElevatorHeightInches() + deltaElevatorHeight,
+                                theElevator.getDesiredCarriageHeightInches() + deltaCarriageHeight)),
+                // new MoveElevator(theElevator,
+                // theElevator.getDesiredElevatorHeightInches()+deltaArmAngle,
+                // theElevator.getDesiredCarriageHeightInches()+deltaArmAngle-1.0),
+                new InstantCommand(() -> theGripper.stop()),
+                new PositionGripper(armStateManager, ArmState.Running, theElevator, theArm, theWrist).command());
     }
 }
-

--- a/src/main/java/frc/robot/commands/ScoreCoralWithoutTravel.java
+++ b/src/main/java/frc/robot/commands/ScoreCoralWithoutTravel.java
@@ -4,6 +4,10 @@
 
 package frc.robot.commands;
 
+import java.util.Set;
+
+import org.littletonrobotics.junction.Logger;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -15,87 +19,61 @@ import frc.robot.subsystems.Gripper;
 import frc.robot.subsystems.Wrist;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
-public class ScoreCoralWithoutTravel extends Command {
+public class ScoreCoralWithoutTravel {
 
-    private ArmStateManager armStateManager ;
+    private ArmStateManager armStateManager;
     private ArmState currentState;
 
-    private final Elevator theElevator ;
+    private final Elevator theElevator;
     private final Arm theArm;
-    private final Wrist theWrist ;
-    private final Gripper theGripper ;
-
-    private Command currentCommand;
-
+    private final Wrist theWrist;
+    private final Gripper theGripper;
 
     // private final Gripper gripperSub;
 
-    public ScoreCoralWithoutTravel(ArmStateManager asm, Elevator e, Arm a, Wrist w,  Gripper g) {
-        armStateManager = asm ;
-        theElevator = e ;
-        theArm = a ;
-        theWrist = w ;
-        theGripper = g ;
-
-        addRequirements(theElevator, theArm, theWrist, theGripper );
+    public ScoreCoralWithoutTravel(ArmStateManager asm, Elevator e, Arm a, Wrist w, Gripper g) {
+        armStateManager = asm;
+        theElevator = e;
+        theArm = a;
+        theWrist = w;
+        theGripper = g;
     }
 
+    public Command command() {
+        return Commands.defer(() -> {
+            currentState = armStateManager.getCurrentState();
 
-    private Command createL234ScoreCommand( double deltaElevatorHeight, double deltaCarriageHeight, double deltaArmAngle) {
+            if (currentState == ArmState.Level1) {
+                return Commands.sequence(
+                        new EjectCoral(theGripper).withTimeout(1.0),
+                        new StopGripper(theGripper));
+            } else if (currentState == ArmState.Level2) {
+                return createL234ScoreCommand(0, -7.0, -30);
+            } else if (currentState == ArmState.Level3) {
+                return createL234ScoreCommand(0, -7.0, -30);
+            } else if (currentState == ArmState.Level4) {
+                return createL234ScoreCommand(0, -4.0, -30);
+            } else {
+                return new NoOpCommand();
+            }
+        },
+                Set.of(theElevator, theArm, theWrist, theGripper));
+    }
+
+    private Command createL234ScoreCommand(double deltaElevatorHeight, double deltaCarriageHeight,
+            double deltaArmAngle) {
 
         return Commands.sequence(
-            // new InstantCommand(() -> theGripper.setReleaseMode() ),
-            new ParallelCommandGroup(
-                new InstantCommand( ()-> theGripper.releaseCoral()),
-                // new MoveArm( theArm, theArm.getArmEncoderDegrees()+deltaArmAngle) ,
-                new MoveElevator(theElevator, theElevator.getDesiredElevatorHeightInches()+deltaElevatorHeight, theElevator.getDesiredCarriageHeightInches()+deltaCarriageHeight) 
-            ) ,
-            // new MoveElevator(theElevator, theElevator.getDesiredElevatorHeightInches()+deltaArmAngle, theElevator.getDesiredCarriageHeightInches()+deltaArmAngle-1.0), 
-            new InstantCommand( ()-> theGripper.stop())
-            );            
-    }
-
-
-
-    // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-
-        currentState = armStateManager.getCurrentState();
-
-        if (currentState == ArmState.Level1) {
-            currentCommand = Commands.sequence(
-                new EjectCoral( theGripper).withTimeout(1.0) ,
-                new StopGripper(theGripper)
-            ) ;
-        } else if (currentState == ArmState.Level2) {
-            currentCommand = createL234ScoreCommand(0, -7.0, -30) ;
-        } else if (currentState == ArmState.Level3) {
-            currentCommand = createL234ScoreCommand(0, -7.0, -30) ;
-        } else if (currentState == ArmState.Level4){
-            currentCommand = createL234ScoreCommand(0, -4.0, -30) ;
-        } else {
-            // can't score coral if your not at one of the levels
-            currentCommand = new NoOpCommand() ;
-        }
-        currentCommand.schedule();
-    }
-
-
-    // Called every time the scheduler runs while the command is scheduled.
-    @Override
-    public void execute() {
-    }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-    }
-
-    // Returns true when the command should end.
-    @Override
-    public boolean isFinished() {
-        return currentCommand.isFinished() ;
+                // new InstantCommand(() -> theGripper.setReleaseMode() ),
+                new ParallelCommandGroup(
+                        new InstantCommand(() -> theGripper.releaseCoral()),
+                        // new MoveArm( theArm, theArm.getArmEncoderDegrees()+deltaArmAngle) ,
+                        new MoveElevator(theElevator,
+                                theElevator.getDesiredElevatorHeightInches() + deltaElevatorHeight,
+                                theElevator.getDesiredCarriageHeightInches() + deltaCarriageHeight)),
+                // new MoveElevator(theElevator,
+                // theElevator.getDesiredElevatorHeightInches()+deltaArmAngle,
+                // theElevator.getDesiredCarriageHeightInches()+deltaArmAngle-1.0),
+                new InstantCommand(() -> theGripper.stop()));
     }
 }
-


### PR DESCRIPTION
Based on the discovery from  @kinahawi and @BrianWeiss1 this afternoon I investigated the internal implementation of command sequence/parallel groups to understand how things are working and see if I could find a workaround.

My primary learning is that `isFinished()` is really designed as a (poorly named) internal contract with the Scheduler and NOT generally intended to be a public-facing accessor to determine if the command has finished running.

In general, all of the Command-wrapper classes (Sequential, Parallel, Deferred, etc) DON'T use the scheduler, but rather take on the scheduler responsibility of running commands themselves, proxying the schedule-API-contract through to the wrapped commands.

See, for example, [DeferredCommand](https://github.com/wpilibsuite/allwpilib/blob/main/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java)

Fortunately, the pattern we have been following of at-initialization-time running some code to determine a command, and then subsequently executing it and finishing when that command has finished is Exactly what DefferedCommand is intended to do.

I found all the places where we've been using that pattern and swapped them to instead by helper-classes that produce a DeferredCommand instance and this appears to have solved all of the issues. Sequencing looks right in simulation.

I also played around with a quick-and-dirty pattern for monitoring state transitions by inserting logs via InstantCommand. I found this much nicer to get a sense of what's happening on the timeline.